### PR TITLE
Support full-filenames including path 

### DIFF
--- a/fig2idtf/auxiliary/mesh_normals.m
+++ b/fig2idtf/auxiliary/mesh_normals.m
@@ -24,7 +24,7 @@ end
 
 hf = figure('Visible','off');
 hp = patch('vertices',points,'faces',faces);
-normals = get(hp,'VertexNormals');
+normals = get(hp,'Vertices'); % workaround
 close(hf);
 %Make the normals unit norm
 norms = sqrt(sum(normals.*conj(normals),2));

--- a/fig2idtf/preprocess/u3d_pre_contourgroup.m
+++ b/fig2idtf/preprocess/u3d_pre_contourgroup.m
@@ -50,15 +50,16 @@ else
 end
 
 % hggroup = contourgroup ?
+noCGroupLIdxs =  false(length(sh),1);
 for i=1:size(sh, 1)
     cursh = sh(i, 1);
     
     if ~isprop(cursh, 'ContourMatrix')
-        sh(i, 1) = nan;
+        noCGroupLIdxs(i) = true;
     end
 end
 
-sh(isnan(sh) ) = [];
+sh(noCGroupLIdxs) = [];
 
 if isempty(sh)
     vertices = [];

--- a/fig2idtf/preprocess/u3d_pre_patch.m
+++ b/fig2idtf/preprocess/u3d_pre_patch.m
@@ -45,7 +45,7 @@ if nargin < 1
     sh = findobj('flat', 'type', 'patch');
 else
     objs = get(ax, 'Children');
-    sh = findobj(objs, 'flat', 'type', 'patch');
+    sh = findobj(objs, 'type', 'patch'); %HA: was ''flat'
 end
 
 if isempty(sh)

--- a/fig2idtf/preprocess/u3d_pre_quivergroup.m
+++ b/fig2idtf/preprocess/u3d_pre_quivergroup.m
@@ -52,15 +52,16 @@ else
 end
 
 % hggroup = quivergroup ?
+noQGroupLIdxs =  false(length(sh),1);
 for i=1:size(sh, 1)
     cursh = sh(i, 1);
     
     if ~isprop(cursh, 'ShowArrowHead')
-        sh(i, 1) = nan;
+        noQGroupLIdxs(i) = true;
     end
 end
 
-sh(isnan(sh) ) = [];
+sh(noQGroupLIdxs) = [];
 
 if isempty(sh)
     vertices = [];

--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -171,6 +171,14 @@ while(~strcmp(ax.Type, 'axes'))  % e.g. hggroup
 end
 realcolor = scaled_ind2rgb(cdata, ax);
 
+%% single rgb-color triplet set (to be applied for the complete surface) HA
+if(length(facecolor) == 3)
+   realcolor = zeros(size(cdata,1),size(cdata,2),3);
+   realcolor(:,:,1) = facecolor(1);
+   realcolor(:,:,2) = facecolor(2);
+   realcolor(:,:,3) = facecolor(3);
+end
+
 function [realcolor] = scaled_ind2rgb(cdata, ax)
 [n, m] = size(cdata);
 cdata = double(cdata);

--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -166,6 +166,9 @@ end
 
 %% indexed color to RGB true color
 ax = get(h, 'Parent');
+while(~strcmp(ax.Type, 'axes'))  % e.g. hggroup
+    ax = get(ax, 'Parent'); % move upwards 
+end
 realcolor = scaled_ind2rgb(cdata, ax);
 
 function [realcolor] = scaled_ind2rgb(cdata, ax)

--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -143,12 +143,12 @@ if strcmp(facecolor, 'texturemap')
     realcolor = [];
     return
 end
-cdata = get(h, 'CData');
 
 % texturemapping is when CData is an image and has different size than
 % XData and the number of faces, so it is not treated here yet.
 
 %% CData
+cdata = get(h, 'CData');
 k = size(cdata, 3);
 
 % true color ?
@@ -166,19 +166,8 @@ end
 
 %% indexed color to RGB true color
 ax = get(h, 'Parent');
-while(~strcmp(ax.Type, 'axes'))  % e.g. hggroup
-    ax = get(ax, 'Parent'); % move upwards 
-end
 realcolor = scaled_ind2rgb(cdata, ax);
 
-%% single color set HA
-if(length(facecolor) == 3)
-   realcolor = zeros(size(cdata,1),size(cdata,2),3);
-   realcolor(:,:,1) = facecolor(1);
-   realcolor(:,:,2) = facecolor(2);
-   realcolor(:,:,3) = facecolor(3);
-   return
-end
 function [realcolor] = scaled_ind2rgb(cdata, ax)
 [n, m] = size(cdata);
 cdata = double(cdata);

--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -143,12 +143,12 @@ if strcmp(facecolor, 'texturemap')
     realcolor = [];
     return
 end
+cdata = get(h, 'CData');
 
 % texturemapping is when CData is an image and has different size than
 % XData and the number of faces, so it is not treated here yet.
 
 %% CData
-cdata = get(h, 'CData');
 k = size(cdata, 3);
 
 % true color ?
@@ -166,8 +166,19 @@ end
 
 %% indexed color to RGB true color
 ax = get(h, 'Parent');
+while(~strcmp(ax.Type, 'axes'))  % e.g. hggroup
+    ax = get(ax, 'Parent'); % move upwards 
+end
 realcolor = scaled_ind2rgb(cdata, ax);
 
+%% single color set HA
+if(length(facecolor) == 3)
+   realcolor = zeros(size(cdata,1),size(cdata,2),3);
+   realcolor(:,:,1) = facecolor(1);
+   realcolor(:,:,2) = facecolor(2);
+   realcolor(:,:,3) = facecolor(3);
+   return
+end
 function [realcolor] = scaled_ind2rgb(cdata, ax)
 [n, m] = size(cdata);
 cdata = double(cdata);

--- a/idtf2u3d/idtf2u3d.m
+++ b/idtf2u3d/idtf2u3d.m
@@ -114,4 +114,6 @@ end
 
 function [fname] = full_fname_with_extension(fname, extension)
 fname = check_file_extension(fname, extension);
-fname  = fullfile(cd, fname);
+if(isempty(fileparts(fname)))
+    fname  = fullfile(cd, fname);
+end

--- a/idtf2u3d/idtf2u3d.m
+++ b/idtf2u3d/idtf2u3d.m
@@ -114,6 +114,4 @@ end
 
 function [fname] = full_fname_with_extension(fname, extension)
 fname = check_file_extension(fname, extension);
-if(isempty(fileparts(fname)))
-    fname  = fullfile(cd, fname);
-end
+fname  = fullfile(cd, fname);


### PR DESCRIPTION
Make call like fig2pdf3d(gca, ‘/foo/bar/filename’) work too (crashed
before)