### PR TITLE
Feature support hggroups

### DIFF
--- a/fig2idtf/preprocess/u3d_pre_patch.m
+++ b/fig2idtf/preprocess/u3d_pre_patch.m
@@ -45,7 +45,7 @@ if nargin < 1
     sh = findobj('flat', 'type', 'patch');
 else
     objs = get(ax, 'Children');
-    sh = findobj(objs, 'flat', 'type', 'patch');
+    sh = findobj(objs, 'type', 'patch'); %HA: was ''flat'
 end
 
 if isempty(sh)

--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -166,6 +166,9 @@ end
 
 %% indexed color to RGB true color
 ax = get(h, 'Parent');
+while(~strcmp(ax.Type, 'axes'))  % e.g. hggroup
+    ax = get(ax, 'Parent'); % move upwards 
+end
 realcolor = scaled_ind2rgb(cdata, ax);
 
 function [realcolor] = scaled_ind2rgb(cdata, ax)


### PR DESCRIPTION
Add support for hggoups. The code until now assumed that the parent of a graphics handle is an axes object. This is not true for more complex graphics object hierarchies (e.g. involving groups of handles by hggroups). Thus traverse the graphics tree upwards in case the parent is not an axes until the axes is finally found.