### PR TITLE
Fix usage with full-filename including path

### DIFF
--- a/idtf2u3d/idtf2u3d.m
+++ b/idtf2u3d/idtf2u3d.m
@@ -114,4 +114,6 @@ end
 
 function [fname] = full_fname_with_extension(fname, extension)
 fname = check_file_extension(fname, extension);
-fname  = fullfile(cd, fname);
+if(isempty(fileparts(fname)))
+    fname  = fullfile(cd, fname);
+end


### PR DESCRIPTION
Make a call like fig2pdf3d(gca, ‘/foo/bar/filename’) work too (crashed
before)