### PR TITLE
Fix surfaces with single color for all faces/vertices

### DIFF
--- a/fig2idtf/preprocess/u3d_pre_surface.m
+++ b/fig2idtf/preprocess/u3d_pre_surface.m
@@ -168,6 +168,14 @@ end
 ax = get(h, 'Parent');
 realcolor = scaled_ind2rgb(cdata, ax);
 
+%% single rgb-color triplet set (to be applied for the complete surface) HA
+if(length(facecolor) == 3)
+   realcolor = zeros(size(cdata,1),size(cdata,2),3);
+   realcolor(:,:,1) = facecolor(1);
+   realcolor(:,:,2) = facecolor(2);
+   realcolor(:,:,3) = facecolor(3);
+end
+
 function [realcolor] = scaled_ind2rgb(cdata, ax)
 [n, m] = size(cdata);
 cdata = double(cdata);


### PR DESCRIPTION
Fix surfaces with single color for all faces/vertices that still have indexed color CData set which however is not used by Matlab due to specified single
solid color. (Example: create streamtube, set FaceColor for streamtube object,
Matlab plots streamtube (correctly) in the set color but fig2idtf still
generates an index color stream tube cycling through the complete
colormap without this fix)